### PR TITLE
Upgrade `opencv_python` to `4.2.0.34` version

### DIFF
--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -13,6 +13,6 @@ trollius==2.1.post2
 pyqt5==5.13.2
 catkin-pkg==0.4.14
 rospkg==1.1.10
-opencv_python==4.2.0
+opencv_python==4.2.0.34
 scipy==1.4.1
 


### PR DESCRIPTION
when installing `opencv_python` with `4.2.0` version, this error occurred:

```
ERROR: Could not find a version that satisfies the requirement opencv_python==4.2.0 (from versions: 3.2.0.7, 3.2.0.8, 3.3.0.9, 3.3.0.10, 3.3.1.11, 3.4.0.12, 3.4.0.14, 3.4.1.15, 3.4.2.16, 3.4.2.17, 3.4.3.18, 3.4.4.19, 3.4.5.20, 3.4.6.27, 3.4.7.28, 3.4.8.29, 3.4.9.31, 3.4.9.33, 3.4.10.35, 3.4.10.37, 3.4.11.39, 3.4.11.41, 3.4.11.43, 3.4.11.45, 3.4.13.47, 3.4.14.51, 3.4.14.53, 3.4.15.55, 3.4.16.57, 3.4.16.59, 3.4.17.61, 3.4.17.63, 3.4.18.65, 4.0.0.21, 4.0.1.23, 4.0.1.24, 4.1.0.25, 4.1.1.26, 4.1.2.30, 4.2.0.32, 4.2.0.34, 4.3.0.36, 4.3.0.38, 4.4.0.40, 4.4.0.42, 4.4.0.44, 4.4.0.46, 4.5.1.48, 4.5.2.52, 4.5.2.54, 4.5.3.56, 4.5.4.58, 4.5.4.60, 4.5.5.62, 4.5.5.64, 4.6.0.66, 4.7.0.68, 4.7.0.72)
ERROR: No matching distribution found for opencv_python==4.2.0

```